### PR TITLE
getSensorEvent fix for SH2_GYRO_INTEGRATED_RV

### DIFF
--- a/src/Adafruit_BNO08x.cpp
+++ b/src/Adafruit_BNO08x.cpp
@@ -217,7 +217,7 @@ bool Adafruit_BNO08x::getSensorEvent(sh2_SensorValue_t *value) {
 
   sh2_service();
 
-  if (value->timestamp == 0) {
+  if (value->timestamp == 0 && value->sensorId != SH2_GYRO_INTEGRATED_RV) {
     // no new events
     return false;
   }


### PR DESCRIPTION
This is a small fix for report type SH2_GYRO_INTEGRATED_RV.  Currently the logic that in Adafruit_BNO08x::getSensorEvent() always returns false for SH2_GYRO_INTEGRATED_RV reports meaning that application code will not be informed that a new report has been processed.  
SH2_GYRO_INTEGRATED_RV is an unusual report in that it has no timestamp

From the datasheet....

![image](https://user-images.githubusercontent.com/15650427/112755342-24eaaf00-8fd8-11eb-897f-d04d8e6f7eaa.png)

As there is no timestamp for this report - the current logic doesn't make sense.

An alternative fix would be to change the logic here:
https://github.com/adafruit/Adafruit_BNO08x/blob/c694323952c9c202887ef2f5628c929d89429965/src/sh2_SensorValue.c#L85

....to add a dummy timestamp

After making this change - my arduino app gets informed of this report type.
