### PR TITLE
Update Adafruit_BNO08x.cpp

### DIFF
--- a/src/Adafruit_BNO08x.cpp
+++ b/src/Adafruit_BNO08x.cpp
@@ -336,6 +336,12 @@ static int i2chal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
       return 0;
     }
 
+    // Drop invalid packet
+    packet_size = (uint16_t)i2c_buffer[0] | (uint16_t)i2c_buffer[1] << 8;
+    if (packet_size == 0) {
+        continue;
+    }
+
     if (first_read) {
       // The first time we're saving the "original" header, so include it in the
       // cargo count


### PR DESCRIPTION
Check the length field of the header for invalid packet. 

In the original implementation, the I2C read function check the length field of the initial 4-byte header. The same check should apply to subsequent packets. 

