### PR TITLE
Fix ESP32 compiler errors

### DIFF
--- a/examples/more_reports/more_reports.ino
+++ b/examples/more_reports/more_reports.ino
@@ -299,7 +299,6 @@ void loop() {
 
     sh2_PersonalActivityClassifier_t activity =
         sensorValue.un.personalActivityClassifier;
-    uint8_t page_num = activity.page;
     Serial.print("Activity classification - Most likely: ");
     printActivity(activity.mostLikelyState);
     Serial.println("");

--- a/src/Adafruit_BNO08x.h
+++ b/src/Adafruit_BNO08x.h
@@ -64,28 +64,28 @@ protected:
       _HAL; ///< The struct representing the SH2 Hardware Abstraction Layer
 };
 
-static int i2chal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
-static int i2chal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
-                       uint32_t *t_us);
-static void i2chal_close(sh2_Hal_t *self);
-static int i2chal_open(sh2_Hal_t *self);
+// static int i2chal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
+// static int i2chal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
+//                        uint32_t *t_us);
+// static void i2chal_close(sh2_Hal_t *self);
+// static int i2chal_open(sh2_Hal_t *self);
 
-static int uarthal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
-static int uarthal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
-                        uint32_t *t_us);
-static void uarthal_close(sh2_Hal_t *self);
-static int uarthal_open(sh2_Hal_t *self);
+// static int uarthal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
+// static int uarthal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
+//                         uint32_t *t_us);
+// static void uarthal_close(sh2_Hal_t *self);
+// static int uarthal_open(sh2_Hal_t *self);
 
-static bool spihal_wait_for_int(void);
-static int spihal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
-static int spihal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
-                       uint32_t *t_us);
-static void spihal_close(sh2_Hal_t *self);
-static int spihal_open(sh2_Hal_t *self);
+// static bool spihal_wait_for_int(void);
+// static int spihal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
+// static int spihal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
+//                        uint32_t *t_us);
+// static void spihal_close(sh2_Hal_t *self);
+// static int spihal_open(sh2_Hal_t *self);
 
-static uint32_t hal_getTimeUs(sh2_Hal_t *self);
-static void hal_callback(void *cookie, sh2_AsyncEvent_t *pEvent);
-static void sensorHandler(void *cookie, sh2_SensorEvent_t *pEvent);
-static void hal_hardwareReset(void);
+// static uint32_t hal_getTimeUs(sh2_Hal_t *self);
+// static void hal_callback(void *cookie, sh2_AsyncEvent_t *pEvent);
+// static void sensorHandler(void *cookie, sh2_SensorEvent_t *pEvent);
+// static void hal_hardwareReset(void);
 
 #endif

--- a/src/Adafruit_BNO08x.h
+++ b/src/Adafruit_BNO08x.h
@@ -64,28 +64,4 @@ protected:
       _HAL; ///< The struct representing the SH2 Hardware Abstraction Layer
 };
 
-// static int i2chal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
-// static int i2chal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
-//                        uint32_t *t_us);
-// static void i2chal_close(sh2_Hal_t *self);
-// static int i2chal_open(sh2_Hal_t *self);
-
-// static int uarthal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
-// static int uarthal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
-//                         uint32_t *t_us);
-// static void uarthal_close(sh2_Hal_t *self);
-// static int uarthal_open(sh2_Hal_t *self);
-
-// static bool spihal_wait_for_int(void);
-// static int spihal_write(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len);
-// static int spihal_read(sh2_Hal_t *self, uint8_t *pBuffer, unsigned len,
-//                        uint32_t *t_us);
-// static void spihal_close(sh2_Hal_t *self);
-// static int spihal_open(sh2_Hal_t *self);
-
-// static uint32_t hal_getTimeUs(sh2_Hal_t *self);
-// static void hal_callback(void *cookie, sh2_AsyncEvent_t *pEvent);
-// static void sensorHandler(void *cookie, sh2_SensorEvent_t *pEvent);
-// static void hal_hardwareReset(void);
-
 #endif


### PR DESCRIPTION
For #19.

* Move static prototypes from .h to .cpp
* Remove numerous unused variables