### PR TITLE
Update i2chal_open - fix for ESP32

### DIFF
--- a/src/Adafruit_BNO08x.cpp
+++ b/src/Adafruit_BNO08x.cpp
@@ -285,22 +285,18 @@ bool Adafruit_BNO08x::enableReport(sh2_SensorId_t sensorId,
 
 static int i2chal_open(sh2_Hal_t *self) {
   // Serial.println("I2C HAL open");
-
-  // send a software reset
   uint8_t softreset_pkt[] = {5, 0, 1, 0, 1};
-  // Serial.println("Sending softreset");
-  if (!i2c_dev->write(softreset_pkt, 5)) {
-    return -1;
+  bool success = false;
+  for (uint8_t attempts = 0; attempts < 5; attempts++) {
+    if (i2c_dev->write(softreset_pkt, 5)) {
+      success = true;
+      break;
+    }
+    delay(30);
   }
-  // Serial.println("OK!");
-  delay(100);
-
-  if (!i2c_dev->write(softreset_pkt, 5)) {
+  if (!success)
     return -1;
-  }
-  // Serial.println("OK!");
-  delay(100);
-
+  delay(300);
   return 0;
 }
 


### PR DESCRIPTION
For #18. Updates reset logic used in `i2chal_open` to better work with ESP32. See issue thread for more details, which also links to forum threads with even more details.

Running `more_reports` example on a QT PY ESP32.

**BEFORE**
```
Adafruit BNO08x test!
Failed to find BNO08x chip
```
**AFTER**
```
Adafruit BNO08x test!
BNO08x Found!
Part 10004148: Version :3.2.13 Build 6
Part 10003606: Version :1.2.4 Build 230
Part 10003254: Version :4.4.3 Build 485
Part 10003171: Version :4.2.10 Build 548
Setting desired reports
Reading events
sensor was reset Setting desired reports
Game Rotation Vector - r: 1.00 i: 0.01 j: 0.07 k: 0.00
Step Counter - steps: 0 latency: 16374
Raw Accelerometer - x: 64 y: 512 z: 3920
Game Rotation Vector - r: 1.00 i: 0.01 j: 0.07 k: 0.00
Step Counter - steps: 0 latency: 30173
Gyro - x: -0.02 y: 0.03 z: -0.03
Game Rotation Vector - r: 1.00 i: 0.01 j: 0.07 k: 0.00
Step Counter - steps: 0 latency: 31645
Game Rotation Vector - r: 1.00 i: 0.01 j: 0.07 k: 0.00
```